### PR TITLE
feature(Count Applicants): Count the Checkboxes of an Applicant

### DIFF
--- a/frontend/pages/bootie/application.tsx
+++ b/frontend/pages/bootie/application.tsx
@@ -14,6 +14,7 @@ import { NextPage } from "next";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import { sections, listTypes } from "../../lib/bootie_constants";
+import countApplicantCheckboxes from "../../utility/countApplicantChecks";
 import { styled } from "@mui/material/styles";
 import LinearProgress, {
   linearProgressClasses,
@@ -95,7 +96,7 @@ const Application: NextPage = () => {
               item.type === listTypes.RADIO
             ) {
               setOpen(true);
-              document.getElementById(item.id)?.click()
+              document.getElementById(item.id)?.click();
               complete = false;
             }
           });

--- a/frontend/utility/countApplicantChecks.ts
+++ b/frontend/utility/countApplicantChecks.ts
@@ -1,13 +1,28 @@
 const { Client } = require("@notionhq/client");
 
-const notion = new Client({
-  auth: process.env.NOTION_SECRET,
-});
+const countApplicantCheckboxes = async (pageId: string) => {
+  const notion = new Client({
+    auth: process.env.NOTION_SECRET,
+  });
 
-const countApplicantCheckboxes = async () => {
-  const pageId = "59833787-2cf9-4fdf-8782-e53db20768a5";
-  const response = await notion.pages.retrieve({ page_id: pageId });
-  return response;
+  const data = await notion.pages.retrieve({
+    page_id: pageId,
+  });
+
+  const properties = data.properties;
+
+  let count = 0;
+
+  for (const property in properties) {
+    if (
+      properties[property].hasOwnProperty("checkbox") &&
+      properties[property].checkbox
+    ) {
+      count += 1;
+    }
+  }
+
+  return count;
 };
 
 export default countApplicantCheckboxes;


### PR DESCRIPTION
### Description

Closes #25 

- [x] Added a script to the utility folder to scrape the number of checkboxes for an applicant based on their page_id

### Type of change

🆕 Feature

### How to Test

- Add another property to the database that is of the type "checkbox"
- Check and uncheck the box and run the script to print the number of marked checkboxes

### Future Goals

- Find the number of checkboxes based on the applicant name instead of page id

### Checklist

- [ ] Code follows design and style guidelines
- [ ] Code is commented with doc blocks
- [ ] Latest code has been rebased from base branch (usually `develop`)
- [ ] Commits follow guidelines (concise, squashed, etc)
- [ ] Github issues have been linked in relevant commits
- [ ] Relevant reviewers (EM) have been assigned to this PR
